### PR TITLE
Add difficulty levels to Violetnova

### DIFF
--- a/planet_progress.json
+++ b/planet_progress.json
@@ -1,1 +1,1 @@
-{"last_planet": "mercury", "furthest_planet": "jupiter"}
+{"last_planet": "earth", "furthest_planet": "neptune"}

--- a/src/config.py
+++ b/src/config.py
@@ -50,7 +50,7 @@ SPACECRAFT_MAX_LIVES = 3
 SPACECRAFT_INVULNERABILITY_TIME = 90  # quadros (1.5s a 60fps)
 
 # Configurações do menu
-MENU_OPTIONS = ["Jogar", "Configurações", "Créditos", "Sair"]
+MENU_OPTIONS = ["Jogar", "Dificuldade", "Configurações", "Créditos", "Sair"]
 MENU_OPTION_SPACING = 50
 MENU_START_Y = 280
 SPACECRAFT_KNOCKBACK = -3.5
@@ -71,3 +71,48 @@ WEAPON_DURATION = 600  # quadros (10s a 60fps)
 # Durações do quiz
 QUIZ_DURATION = 600  # quadros (10s a 60fps)
 QUIZ_RESULT_DURATION = 120  # quadros (2s a 60fps)
+
+# ================================
+# Configurações de dificuldade
+# ================================
+
+# Níveis de dificuldade
+DIFFICULTY_EASY = 0
+DIFFICULTY_MEDIUM = 1
+DIFFICULTY_HARD = 2
+
+# Dificuldade padrão
+DEFAULT_DIFFICULTY = DIFFICULTY_MEDIUM
+
+# Configurações específicas de cada dificuldade
+DIFFICULTY_SETTINGS = {
+    DIFFICULTY_EASY: {
+        "lives": 3,
+        "life_collectible_chance": 0.15,
+        "weapon_collectible_chance": 0.20,
+        "obstacle_distance_multiplier": 1.5,
+        "save_checkpoint": True
+    },
+    DIFFICULTY_MEDIUM: {
+        "lives": 1,
+        "life_collectible_chance": 0.05,
+        "weapon_collectible_chance": 0.10,
+        "obstacle_distance_multiplier": 1.0,
+        "save_checkpoint": False,
+        "max_lives": 3
+    },
+    DIFFICULTY_HARD: {
+        "lives": 1,
+        "life_collectible_chance": 0.0,
+        "weapon_collectible_chance": 0.0,
+        "obstacle_distance_multiplier": 1.0,
+        "save_checkpoint": False
+    },
+}
+
+# Nomes exibidos para cada dificuldade
+DIFFICULTY_NAMES = {
+    DIFFICULTY_EASY: "Fácil",
+    DIFFICULTY_MEDIUM: "Médio",
+    DIFFICULTY_HARD: "Difícil",
+}

--- a/src/game_mechanics.py
+++ b/src/game_mechanics.py
@@ -126,18 +126,25 @@ class GameMechanics:
             
     def generate_collectible(self):
         """Generates a new collectible"""
-        # Place collectible in a safe location
+        settings = config.DIFFICULTY_SETTINGS[self.game.difficulty]
+
+        # Se não houver colecionáveis nesta dificuldade, sai
+        if settings["life_collectible_chance"] == 0 and settings["weapon_collectible_chance"] == 0:
+            return
+
         x = config.SCREEN_WIDTH
         y = random.randint(100, config.SCREEN_HEIGHT - config.FLOOR_HEIGHT - 50)
-        
-        # Determine collectible type (1% chance for life, 10% for weapon, rest data)
-        collectible_type = "data"
+
         rand_val = random.random()
-        if rand_val < 0.01:  # 1% chance for life
+        collectible_type = "data"
+        life_chance = settings["life_collectible_chance"]
+        weapon_chance = settings["weapon_collectible_chance"]
+
+        if rand_val < life_chance:
             collectible_type = "life"
-        elif rand_val < 0.11 and not self.game.weapon_active:  # 10% chance for weapon
+        elif rand_val < life_chance + weapon_chance and not self.game.weapon_active:
             collectible_type = "weapon"
-            
+
         self.game.collectibles.append(Collectible(x, y, collectible_type))
         
     def check_progression(self):
@@ -161,8 +168,12 @@ class GameMechanics:
             next_planet = self.game.planets[self.game.current_planet_index + 1].name.lower()
             self.game.furthest_planet_index = max(self.game.furthest_planet_index, self.game.current_planet_index + 1)
             
-            # Save current planet and update furthest planet
-            self.game.planet_tracker.save(next_planet, update_furthest=True)
+            # Save current planet and update furthest planet, respeitando checkpoints
+            self.game.planet_tracker.save(
+                next_planet,
+                update_furthest=True,
+                allow_save=config.DIFFICULTY_SETTINGS[self.game.difficulty]["save_checkpoint"],
+            )
             
             # Start quiz without incrementing planet index yet - let quiz handle progression
             self.game.state_manager.start_quiz()

--- a/src/game_mechanics.py
+++ b/src/game_mechanics.py
@@ -166,11 +166,12 @@ class GameMechanics:
             
             # Update furthest planet reached
             next_planet = self.game.planets[self.game.current_planet_index + 1].name.lower()
+            current_planet = self.game.current_planet.name.lower()
             self.game.furthest_planet_index = max(self.game.furthest_planet_index, self.game.current_planet_index + 1)
             
             # Save current planet and update furthest planet, respeitando checkpoints
             self.game.planet_tracker.save(
-                next_planet,
+                current_planet,  # Salva o planeta ATUAL, não o próximo
                 update_furthest=True,
                 allow_save=config.DIFFICULTY_SETTINGS[self.game.difficulty]["save_checkpoint"],
             )

--- a/src/highscore.py
+++ b/src/highscore.py
@@ -19,7 +19,10 @@ class PlanetTracker:
             print(f"Erro ao carregar dados de planetas: {e}")
             return {"last_planet": "mercurio", "furthest_planet": "mercurio"}
     
-    def save(self, planet, update_furthest=False):
+    def save(self, planet, update_furthest=False, allow_save=True):
+        if not allow_save:
+            return False
+
         self.last_planet = planet
         
         # Atualiza o planeta mais distante se solicitado

--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -29,19 +29,28 @@ class InputHandler:
             sys.exit()
             
         if self.game.state == config.MENU:
-            # Handle menu navigation
-            if event.key == pygame.K_UP:
-                self.game.selected_menu_option = (self.game.selected_menu_option - 1) % len(config.MENU_OPTIONS)
-                # Play a small click sound if available
-                if hasattr(self.game.sound_manager, 'menu_select_sound'):
-                    self.game.sound_manager.menu_select_sound.play()
-            elif event.key == pygame.K_DOWN:
-                self.game.selected_menu_option = (self.game.selected_menu_option + 1) % len(config.MENU_OPTIONS)
-                # Play a small click sound if available
-                if hasattr(self.game.sound_manager, 'menu_select_sound'):
-                    self.game.sound_manager.menu_select_sound.play()
-            elif event.key == pygame.K_RETURN or event.key == pygame.K_SPACE:
-                self._handle_menu_selection()
+            if self.game.in_difficulty_menu:
+                if event.key == pygame.K_UP:
+                    self.game.selected_difficulty = (self.game.selected_difficulty - 1) % 3
+                elif event.key == pygame.K_DOWN:
+                    self.game.selected_difficulty = (self.game.selected_difficulty + 1) % 3
+                elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    self.game.difficulty = self.game.selected_difficulty
+                    self.game.in_difficulty_menu = False
+                elif event.key == pygame.K_ESCAPE:
+                    self.game.in_difficulty_menu = False
+            else:
+                # Handle main menu navigation
+                if event.key == pygame.K_UP:
+                    self.game.selected_menu_option = (self.game.selected_menu_option - 1) % len(config.MENU_OPTIONS)
+                    if hasattr(self.game.sound_manager, 'menu_select_sound'):
+                        self.game.sound_manager.menu_select_sound.play()
+                elif event.key == pygame.K_DOWN:
+                    self.game.selected_menu_option = (self.game.selected_menu_option + 1) % len(config.MENU_OPTIONS)
+                    if hasattr(self.game.sound_manager, 'menu_select_sound'):
+                        self.game.sound_manager.menu_select_sound.play()
+                elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                    self._handle_menu_selection()
         elif self.game.state == config.QUIZ or self.game.state == config.QUIZ_FAILURE:
             # Only pass events to quiz system if in QUIZ state
             if self.game.state == config.QUIZ:
@@ -116,9 +125,12 @@ class InputHandler:
     def _handle_menu_selection(self):
         """Handles menu option selection"""
         selected_option = config.MENU_OPTIONS[self.game.selected_menu_option]
-        
+
         if selected_option == "Jogar":
             self.game.reset()
+        elif selected_option == "Dificuldade":
+            self.game.in_difficulty_menu = True
+            self.game.selected_difficulty = self.game.difficulty
         elif selected_option == "Configurações":
             # TODO: Implement settings screen
             self.game.nova.show_message("Configurações em breve!", "info")
@@ -132,7 +144,11 @@ class InputHandler:
     def _handle_left_click(self):
         """Handles left mouse button click based on game state"""
         if self.game.state == config.MENU:
-            self.game.reset()
+            if self.game.in_difficulty_menu:
+                self.game.difficulty = self.game.selected_difficulty
+                self.game.in_difficulty_menu = False
+            else:
+                self.game.reset()
         elif self.game.state == config.PLAYING:
             self.game.spacecraft.thrust()
             self.game.sound_manager.play_thrust()

--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -25,8 +25,23 @@ class InputHandler:
     def _handle_key_down(self, event):
         """Handles key press events"""
         if event.key == pygame.K_ESCAPE:
-            pygame.quit()
-            sys.exit()
+            # Se está no menu principal ou submenu de dificuldade
+            if self.game.state == config.MENU:
+                if self.game.in_difficulty_menu:
+                    # Se está no submenu de dificuldade, volta ao menu principal
+                    self.game.in_difficulty_menu = False
+                else:
+                    # Se está no menu principal, sai do jogo
+                    pygame.quit()
+                    sys.exit()
+            else:
+                # Se está jogando, volta ao menu
+                self.game.state_manager.change_state(config.MENU)
+                self.game.state = config.MENU
+                self.game.sound_manager.stop_all_sounds()
+                # Reseta alguns estados
+                self.game.space_held = False
+                self.game.in_difficulty_menu = False
             
         if self.game.state == config.MENU:
             if self.game.in_difficulty_menu:
@@ -36,8 +51,6 @@ class InputHandler:
                     self.game.selected_difficulty = (self.game.selected_difficulty + 1) % 3
                 elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
                     self.game.difficulty = self.game.selected_difficulty
-                    self.game.in_difficulty_menu = False
-                elif event.key == pygame.K_ESCAPE:
                     self.game.in_difficulty_menu = False
             else:
                 # Handle main menu navigation
@@ -101,7 +114,15 @@ class InputHandler:
         elif self.game.state == config.GAME_OVER:
             # Reset welcome_sound_played flag
             self.game.welcome_sound_played = False
-            self.game.reset()
+            # Verifica as configurações de dificuldade
+            difficulty_settings = config.DIFFICULTY_SETTINGS[self.game.difficulty]
+            
+            # Se tem checkpoint, continua do planeta onde morreu
+            # Se não tem checkpoint (médio/difícil), volta para a Terra
+            if difficulty_settings["save_checkpoint"]:
+                self.game.reset(continue_from_death=True)
+            else:
+                self.game.reset()  # Volta para a Terra
         elif self.game.state == config.TRANSITION:
             # Skip transition and force start on new planet
             self.game.reset(new_planet=True)
@@ -127,7 +148,18 @@ class InputHandler:
         selected_option = config.MENU_OPTIONS[self.game.selected_menu_option]
 
         if selected_option == "Jogar":
-            self.game.reset()
+            # Verifica se deve continuar do planeta salvo ou começar novo jogo
+            difficulty_settings = config.DIFFICULTY_SETTINGS[self.game.difficulty]
+            
+            # Se permite checkpoint e tem planeta salvo diferente de Earth/Terra
+            if (difficulty_settings["save_checkpoint"] and 
+                self.game.last_planet.lower() not in ["earth", "terra"] and
+                self.game.current_planet_index > 0):
+                # Continua do planeta salvo
+                self.game.reset(continue_from_saved=True)
+            else:
+                # Começa novo jogo da Terra
+                self.game.reset()
         elif selected_option == "Dificuldade":
             self.game.in_difficulty_menu = True
             self.game.selected_difficulty = self.game.difficulty
@@ -155,7 +187,15 @@ class InputHandler:
         elif self.game.state == config.GAME_OVER:
             # Reset welcome_sound_played flag
             self.game.welcome_sound_played = False
-            self.game.reset()
+            # Verifica as configurações de dificuldade
+            difficulty_settings = config.DIFFICULTY_SETTINGS[self.game.difficulty]
+            
+            # Se tem checkpoint, continua do planeta onde morreu
+            # Se não tem checkpoint (médio/difícil), volta para a Terra
+            if difficulty_settings["save_checkpoint"]:
+                self.game.reset(continue_from_death=True)
+            else:
+                self.game.reset()  # Volta para a Terra
         elif self.game.state == config.TRANSITION:
             # If in transition and sound is playing, allow skipping but continue sound with reduced volume
             if self.game.welcome_sound_timer > 0 and self.game.current_welcome_sound:

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -83,7 +83,7 @@ class UIManager:
         screen.blit(lives_text, (20, 110))
         
         # Draw life icons
-        self.game.visual_effects.draw_life_icons(screen, self.game.lives, config.SPACECRAFT_MAX_LIVES)
+        self.game.visual_effects.draw_life_icons(screen, self.game.lives, self.game.max_lives)
         
         # Draw weapon status at top center if active
         if self.game.weapon_active:
@@ -100,9 +100,13 @@ class UIManager:
         
         title_text = config.GAME_FONT.render("PROJETO VIOLETA NOVA", True, (255, 255, 255))
         subtitle_text = config.SMALL_FONT.render("Explorador do Sistema Solar", True, (200, 200, 255))
-        
+
         screen.blit(title_text, (config.SCREEN_WIDTH // 2 - title_text.get_width() // 2, 180))
         screen.blit(subtitle_text, (config.SCREEN_WIDTH // 2 - subtitle_text.get_width() // 2, 220))
+
+        if self.game.in_difficulty_menu:
+            self.draw_difficulty_menu(screen)
+            return
         
         # Draw menu options
         for i, option in enumerate(config.MENU_OPTIONS):
@@ -139,6 +143,13 @@ class UIManager:
             
             screen.blit(option_text, (config.SCREEN_WIDTH // 2 - option_text.get_width() // 2, y_pos))
         
+        # Show current difficulty
+        diff_name = config.DIFFICULTY_NAMES.get(self.game.difficulty, "")
+        diff_text = config.SMALL_FONT.render(
+            f"Dificuldade: {diff_name}", True, (255, 255, 255)
+        )
+        screen.blit(diff_text, (config.SCREEN_WIDTH // 2 - diff_text.get_width() // 2, config.MENU_START_Y - 40))
+
         # Show controls
         controls_title = config.SMALL_FONT.render("Controles do Menu:", True, (255, 255, 255))
         controls_nav = config.SMALL_FONT.render("SETA PARA CIMA/BAIXO - Navegar | ENTER/ESPAÇO - Selecionar", True, (200, 200, 200))
@@ -244,4 +255,32 @@ class UIManager:
             pygame.font.Font(None, 42),  # Create temporary font for pulsing text
             (255, 255, 255),
             (config.SCREEN_WIDTH // 2, config.SCREEN_HEIGHT // 2 + 100)
+        )
+
+    def draw_difficulty_menu(self, screen):
+        """Desenha o submenu de seleção de dificuldade"""
+        title = config.GAME_FONT.render("Selecione a Dificuldade", True, (255, 255, 255))
+        screen.blit(title, (config.SCREEN_WIDTH // 2 - title.get_width() // 2, 220))
+
+        for i, diff in enumerate([
+            config.DIFFICULTY_EASY,
+            config.DIFFICULTY_MEDIUM,
+            config.DIFFICULTY_HARD,
+        ]):
+            y_pos = config.MENU_START_Y + i * config.MENU_OPTION_SPACING
+            name = config.DIFFICULTY_NAMES[diff]
+            if i == self.game.selected_difficulty:
+                option_text = config.GAME_FONT.render(name, True, (255, 255, 255))
+            else:
+                option_text = config.GAME_FONT.render(name, True, (180, 180, 180))
+            screen.blit(option_text, (config.SCREEN_WIDTH // 2 - option_text.get_width() // 2, y_pos))
+
+        info_text = config.SMALL_FONT.render(
+            "SETA PARA CIMA/BAIXO - Escolher | ENTER - Confirmar | ESC - Voltar",
+            True,
+            (200, 200, 200),
+        )
+        screen.blit(
+            info_text,
+            (config.SCREEN_WIDTH // 2 - info_text.get_width() // 2, config.SCREEN_HEIGHT - 150),
         )

--- a/src/weapon_system.py
+++ b/src/weapon_system.py
@@ -1,5 +1,6 @@
 import pygame
 from src.planet_data import LEVEL_PROGRESSION_THRESHOLDS, PLANET_NAME_PT
+import src.config as config
 
 class WeaponSystem:
     def __init__(self, game):
@@ -72,8 +73,12 @@ class WeaponSystem:
                 next_planet = self.game.planets[self.game.current_planet_index + 1].name.lower()
                 self.game.furthest_planet_index = max(self.game.furthest_planet_index, self.game.current_planet_index + 1)
                 
-                # Save current planet and update furthest planet
-                self.game.planet_tracker.save(next_planet, update_furthest=True)
+                # Save current planet and update furthest planet conforme dificuldade
+                self.game.planet_tracker.save(
+                    next_planet,
+                    update_furthest=True,
+                    allow_save=config.DIFFICULTY_SETTINGS[self.game.difficulty]["save_checkpoint"],
+                )
                 
                 # Start quiz for planet advancement
                 self.game.state_manager.start_quiz()


### PR DESCRIPTION
## Summary
- define difficulty constants and settings in config
- track difficulty in `Game` and apply per-difficulty parameters
- spawn collectibles based on difficulty settings
- add difficulty selection submenu to the menu UI
- handle difficulty input events
- respect checkpoint saving based on difficulty

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`